### PR TITLE
Add Tailscale support for private print server networking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,10 +69,16 @@ VITE_APP_NAME="${APP_NAME}"
 
 PDF_PASSWORD=
 
+# In production PRINT_SERVER_HOST should be the print server's Tailscale IP
+# (100.x.y.z) so print traffic stays on the tailnet.
 PRINT_SERVER_HOST=
 PRINT_SERVER_PORT=
 PRINT_SERVER_USERNAME=
 PRINT_SERVER_PRINTER=Brother_HL_L2405W
+
+# Tailscale auth key (set as a Fly secret in production). When set, the
+# container joins the tailnet at boot via .fly/scripts/tailscale.sh.
+TAILSCALE_AUTHKEY=
 
 STRIPE_KEY=
 STRIPE_SECRET=

--- a/.fly/scripts/tailscale.sh
+++ b/.fly/scripts/tailscale.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Cloudmanic Labs, LLC. All rights reserved.
+# Date: 2026-06-05
+#
+# Start the Tailscale daemon and join our tailnet. This gives the app a
+# private network path to the print server, so the SSH/SCP print jobs no
+# longer need to traverse the public internet.
+#
+
+# Create persistent Tailscale state directory on the data volume so the
+# node identity survives deploys and machine suspends.
+mkdir -p /data/tailscale
+
+# Start the Tailscale daemon with persistent state
+tailscaled --state=/data/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+
+# Wait for the daemon to be ready
+sleep 2
+
+# Connect to the tailnet using the auth key. We pass --accept-dns=false so
+# Tailscale does not take over /etc/resolv.conf — Fly's resolver keeps
+# handling S3/Stripe/SES lookups. Use the print server's Tailscale IP
+# (100.x.y.z) in PRINT_SERVER_HOST rather than a MagicDNS name.
+if [ -n "$TAILSCALE_AUTHKEY" ]; then
+    tailscale up --authkey="$TAILSCALE_AUTHKEY" --hostname="rental-notice" --accept-dns=false
+    echo "Tailscale connected successfully"
+else
+    echo "Warning: TAILSCALE_AUTHKEY not set, skipping Tailscale setup"
+fi

--- a/.fly/ssh/config
+++ b/.fly/ssh/config
@@ -1,0 +1,10 @@
+# Copyright (c) 2026 Cloudmanic Labs, LLC. All rights reserved.
+# Date: 2026-06-05
+#
+# Accept host keys automatically on first connection. The print server is
+# reached over our Tailscale tailnet, which already authenticates the
+# machine, so trust-on-first-use is safe here. Without this, the queue
+# worker's non-interactive scp/ssh would fail host-key verification when
+# the print server host changes (e.g. public DNS -> Tailscale IP).
+Host *
+    StrictHostKeyChecking accept-new

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,9 @@ RUN apt-get update \
 
 RUN go install github.com/pdfcpu/pdfcpu/cmd/pdfcpu@v0.9.1 && cp /root/go/bin/pdfcpu /usr/local/bin/pdfcpu
 
+# Install Tailscale so we can reach the print server over our private tailnet
+RUN curl -fsSL https://tailscale.com/install.sh | sh
+
 # 2. Copy config files to proper locations
 COPY .fly/nginx/ /etc/nginx/
 COPY .fly/fpm/ /etc/php/${PHP_VERSION}/fpm/


### PR DESCRIPTION
## Summary

Adds Tailscale to the Docker image so the SSH/SCP print pipeline (`PrintNoticePackageJob`) can reach the print server over a private tailnet instead of the public internet.

## Changes

- **Dockerfile**: Install Tailscale in the base image
- **`.fly/scripts/tailscale.sh`**: Boot script (runs via the existing entrypoint script loop) that starts `tailscaled` with persistent state on the `/data` volume and joins the tailnet as hostname `rental-notice`. Gracefully skips when `TAILSCALE_AUTHKEY` is not set, so local/dev and pre-secret deploys are unaffected.
- **`.fly/ssh/config`**: `StrictHostKeyChecking accept-new` so the queue worker's non-interactive `scp`/`ssh` won't fail host-key verification when `PRINT_SERVER_HOST` switches to the Tailscale IP.
- **`.env.example`**: Document `TAILSCALE_AUTHKEY` and the Tailscale IP convention for `PRINT_SERVER_HOST`.

Note: unlike course.options.cafe, this passes `--accept-dns=false` so Tailscale does not take over `/etc/resolv.conf` — Fly's resolver keeps handling S3/Stripe/SES lookups. Use the print server's `100.x.y.z` Tailscale IP in `PRINT_SERVER_HOST`.

## Deployment steps (before/after merge)

1. `fly secrets set TAILSCALE_AUTHKEY=tskey-auth-...` (reusable key from the Tailscale admin console)
2. Merge (auto-deploys via GitHub Actions)
3. `fly secrets set PRINT_SERVER_HOST=<print server Tailscale IP>`
4. Verify with `php artisan notice:print <id>`
5. Lock down public SSH on the print server